### PR TITLE
#21 Fix Quiz : quiz 관련 entity 수정 및 퀴즈 저장 API 삭제

### DIFF
--- a/src/main/java/com/finut/finut_server/controller/QuizController.java
+++ b/src/main/java/com/finut/finut_server/controller/QuizController.java
@@ -39,22 +39,6 @@ public class QuizController {
         return ApiResponse.onSuccess(QuizConverter.toGetQuizDto(userId, quiz));
     }
 
-    @Operation(summary = "퀴즈 데이터 저장", description = "생성된 퀴즈 데이터를 DB에 저장합니다.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = QuizResponseDTO.saveQuizDto.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "올바른 날짜나 시간이 아닙니다.",
-                    content = @Content),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorReasonDTO.class)))
-    })
-    @PostMapping("/save")
-    public ApiResponse<QuizResponseDTO.saveQuizDto> saveQuiz(@RequestBody @Valid QuizRequestDTO.saveQuiz request){
-        Quiz quiz = quizService.saveQuiz(request);
-        return ApiResponse.onSuccess(QuizConverter.toSaveQuizDto(quiz));
-    }
-
     @Operation(summary = "퀴즈 정답 판독 후 돈 적립", description = "사용자가 입력한 답이 정답인지 판독한 후, 정답 여부에 따라 돈을 적립합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",

--- a/src/main/java/com/finut/finut_server/converter/QuizConverter.java
+++ b/src/main/java/com/finut/finut_server/converter/QuizConverter.java
@@ -6,26 +6,6 @@ import com.finut.finut_server.domain.quiz.QuizResponseDTO;
 import org.springframework.security.core.parameters.P;
 
 public class QuizConverter {
-    public static QuizResponseDTO.saveQuizDto toSaveQuizDto(Quiz quiz){
-        return QuizResponseDTO.saveQuizDto.builder()
-                .quizId(quiz.getId())
-                .quizContent(quiz.getContent())
-                .quizAnswer(quiz.getAnswer())
-                .quizReason(quiz.getReason())
-                .correctMoney(quiz.getCorrectMoney())
-                .wrongMoney(quiz.getWrongMoney())
-                .build();
-    }
-
-    public static Quiz toQuiz(QuizRequestDTO.saveQuiz request){
-        return com.finut.finut_server.domain.quiz.Quiz.builder()
-                .content(request.getContent())
-                .answer(request.getAnswer())
-                .reason(request.getReason())
-                .correctMoney(request.getCorrectMoney())
-                .wrongMoney(request.getWrongMoney())
-                .build();
-    }
 
     public static QuizResponseDTO.getQuizDto toGetQuizDto(Long userId, Quiz quiz){
         if(quiz == null) {

--- a/src/main/java/com/finut/finut_server/domain/quiz/Quiz.java
+++ b/src/main/java/com/finut/finut_server/domain/quiz/Quiz.java
@@ -17,14 +17,26 @@ public class Quiz extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String content; // 퀴즈 내용
+    private String question; // 퀴즈 내용
 
     @Lob
+    private String option1;
+
+    @Lob
+    private String option2;
+
+    @Lob
+    private String option3;
+
     @Column(nullable = false)
-    private String answer; // 퀴즈 정답
+    @Lob
+    private String answer;
 
     @Column(nullable = false, columnDefinition = "MEDIUMTEXT")
-    private String reason; // 정답 이유
+    private String description; // 정답 설명
+
+    @Column(nullable = false)
+    private String quizType; // 퀴즈 타입: TF or 객관식
 
     @Column(nullable = false)
     private int correctMoney; // 맞춘 경우 얻는 돈

--- a/src/main/java/com/finut/finut_server/domain/quiz/Quiz.java
+++ b/src/main/java/com/finut/finut_server/domain/quiz/Quiz.java
@@ -20,6 +20,7 @@ public class Quiz extends BaseTimeEntity {
     private String question; // 퀴즈 내용
 
     @Lob
+    @Column(nullable = false)
     private String option1;
 
     @Lob
@@ -35,8 +36,11 @@ public class Quiz extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "MEDIUMTEXT")
     private String description; // 정답 설명
 
+    @Enumerated(EnumType.STRING)
+    private QuizType quizType; // 퀴즈 타입: TF or MUL
+
     @Column(nullable = false)
-    private String quizType; // 퀴즈 타입: TF or 객관식
+    private int displayed; // 출제된지 여부 판단 (1: 출제된 적 있음, 0: 출제된 적 없음)
 
     @Column(nullable = false)
     private int correctMoney; // 맞춘 경우 얻는 돈

--- a/src/main/java/com/finut/finut_server/domain/quiz/QuizRequestDTO.java
+++ b/src/main/java/com/finut/finut_server/domain/quiz/QuizRequestDTO.java
@@ -9,19 +9,6 @@ import lombok.Setter;
 @Setter
 @Builder
 public class QuizRequestDTO {
-    @Getter
-    public static class saveQuiz{
-        @NotNull
-        String content;
-        @NotNull
-        String answer;
-        @NotNull
-        String reason;
-        @NotNull
-        int correctMoney; // 맞춘 경우 얻는 돈
-        @NotNull
-        int wrongMoney; // 틀린 경우 얻는 돈
-    }
 
     @Getter
     public static class updateMoney{

--- a/src/main/java/com/finut/finut_server/domain/quiz/QuizResponseDTO.java
+++ b/src/main/java/com/finut/finut_server/domain/quiz/QuizResponseDTO.java
@@ -12,19 +12,6 @@ public class QuizResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class saveQuizDto{
-        Long quizId;
-        String quizContent; // 퀴즈 내용
-        String quizAnswer; // 퀴즈 답
-        String quizReason; // 답 풀이
-        int correctMoney; // 맞춘 경우 얻는 돈
-        int wrongMoney; // 틀린 경우 얻는 돈
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class getQuizDto{
         Long userId; // 접속한 유저의 아이디
         Quiz quiz;

--- a/src/main/java/com/finut/finut_server/domain/quiz/QuizType.java
+++ b/src/main/java/com/finut/finut_server/domain/quiz/QuizType.java
@@ -1,0 +1,6 @@
+package com.finut.finut_server.domain.quiz;
+
+public enum QuizType {
+    TF, // OX
+    MUL // 삼지선다
+}

--- a/src/main/java/com/finut/finut_server/service/QuizService.java
+++ b/src/main/java/com/finut/finut_server/service/QuizService.java
@@ -25,18 +25,6 @@ public class QuizService {
     private QuizRepository quizRepository;
 
     @Transactional
-    public Quiz saveQuiz(QuizRequestDTO.saveQuiz request){
-        if(request.getCorrectMoney() < 0 || request.getWrongMoney() < 0){
-            throw new GeneralException(ErrorStatus.INVALID_NUMBER);
-        }
-
-        Quiz quiz = QuizConverter.toQuiz(request);
-        quiz = quizRepository.save(quiz);
-
-        return quiz;
-    }
-
-    @Transactional
     public Quiz getQuiz(){
         LocalDate today = LocalDate.now();
         return quizRepository.findByDate(today);


### PR DESCRIPTION
## Summary
- 퀴즈 관련 entity 수정
   <img width="1178" alt="image" src="https://github.com/user-attachments/assets/e6818351-5d0e-4723-acff-1cb3c299cdc1">

- 퀴즈 추가하는 API 삭제: 직접 DB에 추가할 예정 (API 필요x)