### PR TITLE
#25 Update User : 출석 확인 후, 돈 지급 API 구현

### DIFF
--- a/src/main/java/com/finut/finut_server/controller/HomeController.java
+++ b/src/main/java/com/finut/finut_server/controller/HomeController.java
@@ -3,6 +3,9 @@ package com.finut.finut_server.controller;
 import com.finut.finut_server.apiPayload.ApiResponse;
 import com.finut.finut_server.apiPayload.code.ErrorReasonDTO;
 import com.finut.finut_server.config.auth.dto.SessionUser;
+import com.finut.finut_server.converter.QuizConverter;
+import com.finut.finut_server.domain.quiz.Quiz;
+import com.finut.finut_server.domain.quiz.QuizResponseDTO;
 import com.finut.finut_server.domain.user.UserResponseDTO;
 import com.finut.finut_server.service.UsersService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +21,7 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/finut/finut_server/controller/UserController.java
+++ b/src/main/java/com/finut/finut_server/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.finut.finut_server.controller;
+
+import com.finut.finut_server.apiPayload.ApiResponse;
+import com.finut.finut_server.apiPayload.code.ErrorReasonDTO;
+import com.finut.finut_server.domain.user.UserRequestDTO;
+import com.finut.finut_server.domain.user.UserResponseDTO;
+import com.finut.finut_server.service.UsersService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User Controller", description = "사용자 관련 api")
+@RequestMapping("/user")
+@RestController
+public class UserController {
+    @Autowired
+    private UsersService usersService;
+
+    @Operation(summary = "출석 체크 하기", description = "출석 체크 시, 돈을 지급하는 API 입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = UserResponseDTO.updateAttendance.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "사용자 정보를 제대로 가지고 오지 못했습니다.",
+                    content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
+    @PatchMapping("")
+    public ApiResponse<UserResponseDTO.updateAttendance> updateAttendance(@RequestBody UserRequestDTO.checkAttendance request){
+        UserResponseDTO.updateAttendance updateAttendance = usersService.updateAttendDate(request.getUserId());
+        return ApiResponse.onSuccess(updateAttendance);
+    }
+}

--- a/src/main/java/com/finut/finut_server/domain/user/UserRequestDTO.java
+++ b/src/main/java/com/finut/finut_server/domain/user/UserRequestDTO.java
@@ -1,0 +1,17 @@
+package com.finut.finut_server.domain.user;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UserRequestDTO {
+    @Getter
+    public static class checkAttendance {
+        @NotNull
+        Long userId; // 접속한 유저의 아이디
+    }
+}

--- a/src/main/java/com/finut/finut_server/domain/user/UserResponseDTO.java
+++ b/src/main/java/com/finut/finut_server/domain/user/UserResponseDTO.java
@@ -14,4 +14,13 @@ public class UserResponseDTO {
         String email;
         String accessToken;
     }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class updateAttendance {
+        Long userId;
+        String message;
+        Boolean isAttend;
+    }
 }

--- a/src/main/java/com/finut/finut_server/domain/user/Users.java
+++ b/src/main/java/com/finut/finut_server/domain/user/Users.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -35,6 +38,9 @@ public class Users extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Long money = 100000L;
+
+    @Column(nullable = false)
+    private String attend = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
     @Builder
     public Users(String name, String email, String picture, String refreshToken, Role role) {

--- a/src/main/java/com/finut/finut_server/service/UsersService.java
+++ b/src/main/java/com/finut/finut_server/service/UsersService.java
@@ -1,5 +1,8 @@
 package com.finut.finut_server.service;
 
+import com.finut.finut_server.apiPayload.code.status.ErrorStatus;
+import com.finut.finut_server.apiPayload.exception.GeneralException;
+import com.finut.finut_server.domain.user.UserResponseDTO;
 import com.finut.finut_server.domain.user.Users;
 import com.finut.finut_server.domain.user.UsersRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +12,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -19,7 +24,6 @@ public class UsersService {
     @Autowired
     private UsersRepository usersRepository;
 
-
     public void saveRefreshToken(String email, String refreshToken) {
         Optional<Users> optionalUser = usersRepository.findByEmail(email);
         if (optionalUser.isPresent()) {
@@ -29,6 +33,32 @@ public class UsersService {
         } else {
             throw new UsernameNotFoundException("User not found");
         }
+    }
+
+    public UserResponseDTO.updateAttendance updateAttendDate(Long userId){
+        String msg = "이미 출석했습니다!";
+        Boolean attend = true;
+        // userId로 attend 날짜 확인
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        LocalDate today = LocalDate.now();
+        String formattedDate = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        if(!user.getAttend().equals(formattedDate)){
+            // 출석을 하지 않은 경우
+            user.setAttend(formattedDate);
+            user.setMoney(user.getMoney() + 100000L); // 출석마다 금액이 바뀌는 등, 기획 수정 시, 코드도 수정 후 반영 예정
+            usersRepository.save(user);
+
+            msg = "출석했습니다!";
+            attend = false;
+        }
+        UserResponseDTO.updateAttendance updateAttendance = UserResponseDTO.updateAttendance.builder()
+                .userId(userId)
+                .message(msg)
+                .isAttend(attend)
+                .build();
+
+        return updateAttendance;
     }
 }
 


### PR DESCRIPTION
## Summary
- 출석 체크 API를 구현했습니다.
1. User Entity: attend 속성 추가 후, 최초 회원가입 시 기본으로 회원가입한 날짜를 저장하도록 지정
2. 출석 체크 로직
    - 오늘 날짜와 attend에 저장되어있는 날짜를 비교
    - 다르면 attend의 날짜를 오늘 날짜로 변경 후, 돈 지급
    - 같으면 아무 동작도 하지 않음