### PR TITLE
[DEV] 오늘의 뉴스 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 
     // mysql 설정
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    //RSS 툴
+    implementation 'com.rometools:rome:1.15.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
+++ b/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
@@ -23,7 +23,7 @@ public class TodayNewsController {
     @Autowired
     private TodayNewsService todayNewsService;
 
-    @Operation(summary = "오늘의 뉴스", description = "오늘의 뉴스 중 경제 부분의 뉴스들을 보여줍니다")
+    @Operation(summary = "오늘의 뉴스 - 경제", description = "오늘의 뉴스 중 경제 부분의 뉴스들을 보여줍니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = QuizResponseDTO.getQuizDto.class))),
@@ -36,7 +36,47 @@ public class TodayNewsController {
     @GetMapping("/economy")
     public List<NewsItemDTO> newsEconomy() {
         try {
-            return todayNewsService.economyFeed();
+            return todayNewsService.getNews(1); // economy
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Fail to fetch RSS Economy", e);
+        }
+    }
+
+    @Operation(summary = "오늘의 뉴스 - 부동산", description = "오늘의 뉴스 중 부동산 부분의 뉴스들을 보여줍니다")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = QuizResponseDTO.getQuizDto.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
+                    content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
+    @GetMapping("/realestate")
+    public List<NewsItemDTO> newsRealEstate() {
+        try {
+            return todayNewsService.getNews(2); // real estate
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Fail to fetch RSS Economy", e);
+        }
+    }
+
+    @Operation(summary = "오늘의 뉴스 - 증권", description = "오늘의 뉴스 중 증권 부분의 뉴스들을 보여줍니다")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = QuizResponseDTO.getQuizDto.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
+                    content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
+    @GetMapping("/stock")
+    public List<NewsItemDTO> newsStock() {
+        try {
+            return todayNewsService.getNews(3); // stock
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("Fail to fetch RSS Economy", e);

--- a/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
+++ b/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
@@ -1,0 +1,30 @@
+package com.finut.finut_server.controller;
+
+import com.finut.finut_server.domain.news.NewsItemDTO;
+import com.finut.finut_server.service.TodayNewsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/news")
+public class TodayNewsController {
+
+    @Autowired
+    private TodayNewsService todayNewsService;
+
+    @GetMapping("/economy")
+    public List<NewsItemDTO> newsEconomy() {
+        try {
+            return todayNewsService.economyFeed();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Fail to fetch RSS Economy", e);
+        }
+    }
+
+}

--- a/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
+++ b/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
@@ -1,7 +1,13 @@
 package com.finut.finut_server.controller;
 
+import com.finut.finut_server.apiPayload.code.ErrorReasonDTO;
 import com.finut.finut_server.domain.news.NewsItemDTO;
+import com.finut.finut_server.domain.quiz.QuizResponseDTO;
 import com.finut.finut_server.service.TodayNewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +23,16 @@ public class TodayNewsController {
     @Autowired
     private TodayNewsService todayNewsService;
 
+    @Operation(summary = "오늘의 뉴스", description = "오늘의 뉴스 중 경제 부분의 뉴스들을 보여줍니다")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = QuizResponseDTO.getQuizDto.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
+                    content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
     @GetMapping("/economy")
     public List<NewsItemDTO> newsEconomy() {
         try {

--- a/src/main/java/com/finut/finut_server/domain/news/NewsItemDTO.java
+++ b/src/main/java/com/finut/finut_server/domain/news/NewsItemDTO.java
@@ -1,0 +1,16 @@
+package com.finut.finut_server.domain.news;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+public class NewsItemDTO {
+    private String title;
+    private String link;
+    private String description;
+    private int number;
+    private String ImageUrl;
+}

--- a/src/main/java/com/finut/finut_server/service/TodayNewsService.java
+++ b/src/main/java/com/finut/finut_server/service/TodayNewsService.java
@@ -19,9 +19,23 @@ import java.util.stream.Collectors;
 @Service
 public class TodayNewsService {
     private static final String economy_URL = "https://www.mk.co.kr/rss/30100041/";
+    private static final String real_estate_URL = "https://www.mk.co.kr/rss/50300009/";
+    private static final String stock_URL = "https://www.mk.co.kr/rss/50200011/";
 
-    public List<NewsItemDTO> economyFeed() throws Exception {
-        URL feedSource = new URL(economy_URL);
+    public List<NewsItemDTO> getNews(int type) throws Exception {
+        URL feedSource;
+        if (type == 1)
+        {
+            feedSource = new URL(economy_URL);
+        }
+        else if (type == 2)
+        {
+            feedSource = new URL(real_estate_URL);
+        }
+        else {
+            feedSource = new URL(stock_URL);
+        }
+
         SyndFeedInput input = new SyndFeedInput();
         SyndFeed feed = input.build(new XmlReader(feedSource));
 

--- a/src/main/java/com/finut/finut_server/service/TodayNewsService.java
+++ b/src/main/java/com/finut/finut_server/service/TodayNewsService.java
@@ -25,7 +25,7 @@ public class TodayNewsService {
         SyndFeedInput input = new SyndFeedInput();
         SyndFeed feed = input.build(new XmlReader(feedSource));
 
-        return feed.getEntries().stream().map(this::convertToNewsItem).collect(Collectors.toList());
+        return feed.getEntries().stream().map(this::convertToNewsItem).limit(10).collect(Collectors.toList());
     }
 
     private NewsItemDTO convertToNewsItem(SyndEntry entry) {

--- a/src/main/java/com/finut/finut_server/service/TodayNewsService.java
+++ b/src/main/java/com/finut/finut_server/service/TodayNewsService.java
@@ -1,0 +1,62 @@
+package com.finut.finut_server.service;
+
+import com.finut.finut_server.domain.news.NewsItemDTO;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.XmlReader;
+import org.springframework.stereotype.Service;
+import com.rometools.rome.io.SyndFeedInput;
+
+import org.jdom2.Element;
+import java.net.URL;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+@Service
+public class TodayNewsService {
+    private static final String economy_URL = "https://www.mk.co.kr/rss/30100041/";
+
+    public List<NewsItemDTO> economyFeed() throws Exception {
+        URL feedSource = new URL(economy_URL);
+        SyndFeedInput input = new SyndFeedInput();
+        SyndFeed feed = input.build(new XmlReader(feedSource));
+
+        return feed.getEntries().stream().map(this::convertToNewsItem).collect(Collectors.toList());
+    }
+
+    private NewsItemDTO convertToNewsItem(SyndEntry entry) {
+        NewsItemDTO news = new NewsItemDTO();
+
+        //URL 에서 number 추출
+        String url = entry.getLink();
+        String[] parts = url.split("/");
+        news.setNumber(Integer.parseInt(parts[parts.length-1]));
+
+        // 기본 정보 설정
+        news.setTitle(entry.getTitle());
+        news.setLink(url.replace("www.", "m."));
+        news.setDescription(entry.getDescription().getValue());
+
+
+        // 이미지 추출
+        String imageUrl = null;
+        List<Element> foreignMarkup = entry.getForeignMarkup();  // 커스텀 태그 추출
+        for (Element element : foreignMarkup) {
+            System.out.println(element);
+            if ("content".equals(element.getName()) && "image".equals(element.getAttributeValue("medium"))) {
+                imageUrl = element.getAttributeValue("url");
+                break;
+            }
+        }
+
+        news.setImageUrl(imageUrl);
+
+
+        return news;
+    }
+
+}


### PR DESCRIPTION
## summary
- 오늘의 뉴스 api 구현

## description
- 경제, 부동산, 증권 api 구현
- 현재 정보만 가져올 뿐 읽었는지 여부는 저장하지 않고 있습니다
- 각 분야 별로 RSS 상위 10개 정보를 가져옵니다
- 다음의 정보들을 가져옵니다
<img width="263" alt="image" src="https://github.com/user-attachments/assets/ed2ede89-7783-4ca3-a62f-db02dd4422cf">
