### PR TITLE
[REFACTOR] 응답 데이터 통일

### DIFF
--- a/src/main/java/com/finut/finut_server/controller/QuizController.java
+++ b/src/main/java/com/finut/finut_server/controller/QuizController.java
@@ -52,7 +52,7 @@ public class QuizController {
     @Operation(summary = "랜덤으로 퀴즈 내용 불러오기", description = "유저가 풀지 않았던 문제 중에서 퀴즈를 랜덤으로 하나 가져옵니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = QuizResponseDTO.randomQuizResponseDTO.class))),
+                    schema = @Schema(implementation = Quiz.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "퀴즈 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -73,7 +73,7 @@ public class QuizController {
     @Operation(summary = "퀴즈를 맞췄을 때", description = "퀴즈를 맞췄을 때 QuizDone DB에 해당 내용을 저장하고, 난이도 상승에 필요한 퀴즈 개수와 레벨업에 필요한 퀴즈 개수를 증가시킵니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = QuizResponseDTO.randomQuizResponseDTO.class))),
+                    schema = @Schema(implementation = String.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "퀴즈 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -102,7 +102,7 @@ public class QuizController {
     @Operation(summary = "퀴즈를 틀렸을 때", description = "퀴즈를 틀렸을 때, 틀렸다는 정보를 저장합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = QuizResponseDTO.randomQuizResponseDTO.class))),
+                    schema = @Schema(implementation = String.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "퀴즈 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",

--- a/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
+++ b/src/main/java/com/finut/finut_server/controller/TodayNewsController.java
@@ -1,10 +1,12 @@
 package com.finut.finut_server.controller;
 
+import com.finut.finut_server.apiPayload.ApiResponse;
 import com.finut.finut_server.apiPayload.code.ErrorReasonDTO;
 import com.finut.finut_server.domain.news.NewsItemDTO;
 import com.finut.finut_server.service.TodayNewsService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -28,7 +30,7 @@ public class TodayNewsController {
     @Operation(summary = "오늘의 뉴스 - 경제", description = "오늘의 뉴스 중 경제 부분의 뉴스들을 보여줍니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))),
+                    array = @ArraySchema(schema = @Schema(implementation = NewsItemDTO.class)))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -36,9 +38,9 @@ public class TodayNewsController {
                             schema = @Schema(implementation = ErrorReasonDTO.class)))
     })
     @GetMapping("/economy")
-    public List<NewsItemDTO> newsEconomy() {
+    public ApiResponse<List<NewsItemDTO>> newsEconomy() {
         try {
-            return todayNewsService.getNews(1); // economy
+            return ApiResponse.onSuccess(todayNewsService.getNews(1)); // economy
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("Fail to fetch RSS Economy", e);
@@ -48,7 +50,7 @@ public class TodayNewsController {
     @Operation(summary = "오늘의 뉴스 - 부동산", description = "오늘의 뉴스 중 부동산 부분의 뉴스들을 보여줍니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))),
+                    array = @ArraySchema(schema = @Schema(implementation = NewsItemDTO.class)))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -56,9 +58,9 @@ public class TodayNewsController {
                             schema = @Schema(implementation = ErrorReasonDTO.class)))
     })
     @GetMapping("/realestate")
-    public List<NewsItemDTO> newsRealEstate() {
+    public ApiResponse<List<NewsItemDTO>> newsRealEstate() {
         try {
-            return todayNewsService.getNews(2); // real estate
+            return ApiResponse.onSuccess(todayNewsService.getNews(2)); // real estate
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("Fail to fetch RSS Economy", e);
@@ -68,7 +70,7 @@ public class TodayNewsController {
     @Operation(summary = "오늘의 뉴스 - 증권", description = "오늘의 뉴스 중 증권 부분의 뉴스들을 보여줍니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))),
+                    array = @ArraySchema(schema = @Schema(implementation = NewsItemDTO.class)))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -76,9 +78,9 @@ public class TodayNewsController {
                             schema = @Schema(implementation = ErrorReasonDTO.class)))
     })
     @GetMapping("/stock")
-    public List<NewsItemDTO> newsStock() {
+    public ApiResponse<List<NewsItemDTO>> newsStock() {
         try {
-            return todayNewsService.getNews(3); // stock
+            return ApiResponse.onSuccess(todayNewsService.getNews(3)); // stock
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("Fail to fetch RSS Economy", e);
@@ -88,7 +90,7 @@ public class TodayNewsController {
     @Operation(summary = "뉴스 본문 - 증권", description = "{number} 증권 뉴스의 본문을 보여줍니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))),
+                    schema = @Schema(implementation = Map.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -96,20 +98,20 @@ public class TodayNewsController {
                             schema = @Schema(implementation = ErrorReasonDTO.class)))
     })
     @GetMapping("/stock/{number}")
-    public Map<String, String> getStockContent(@PathVariable Long number) {
+    public ApiResponse<Map<String, String>> getStockContent(@PathVariable Long number) {
         String url = "https://m.mk.co.kr/news/stock/" + number;
         String content = TodayNewsService.getMainContent(url);
 
         Map<String, String> response = new HashMap<>();
         response.put("content", content);
 
-        return response;
+        return ApiResponse.onSuccess(response);
     }
 
     @Operation(summary = "뉴스 본문 - 경제", description = "{number} 경제 뉴스의 본문을 보여줍니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))),
+                    schema = @Schema(implementation = Map.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -117,20 +119,20 @@ public class TodayNewsController {
                             schema = @Schema(implementation = ErrorReasonDTO.class)))
     })
     @GetMapping("/economy/{number}")
-    public Map<String, String> getEconomyContent(@PathVariable Long number) {
+    public ApiResponse<Map<String, String>> getEconomyContent(@PathVariable Long number) {
         String url = "https://m.mk.co.kr/news/economy/" + number;
         String content = TodayNewsService.getMainContent(url);
 
         Map<String, String> response = new HashMap<>();
         response.put("content", content);
 
-        return response;
+        return ApiResponse.onSuccess(response);
     }
 
     @Operation(summary = "뉴스 본문 - 부동산", description = "{number} 부동산 뉴스의 본문을 보여줍니다")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))),
+                    schema = @Schema(implementation = Map.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "뉴스 내용을 제대로 가지고 오지 못했습니다.",
                     content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다.",
@@ -138,14 +140,14 @@ public class TodayNewsController {
                             schema = @Schema(implementation = ErrorReasonDTO.class)))
     })
     @GetMapping("/realestate/{number}")
-    public Map<String, String> getContent(@PathVariable Long number) {
+    public ApiResponse<Map<String, String>> getContent(@PathVariable Long number) {
         String url = "https://m.mk.co.kr/news/realestate/" + number;
         String content = TodayNewsService.getMainContent(url);
 
         Map<String, String> response = new HashMap<>();
         response.put("content", content);
 
-        return response;
+        return ApiResponse.onSuccess(response);
     }
 
 }

--- a/src/main/java/com/finut/finut_server/domain/difficulty/Difficulty.java
+++ b/src/main/java/com/finut/finut_server/domain/difficulty/Difficulty.java
@@ -7,6 +7,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "Difficulty")
 public class Difficulty {
 
@@ -16,7 +17,6 @@ public class Difficulty {
 
     @Column(nullable = false)
     private int diffQuizCnt;
-
-    @OneToOne(mappedBy = "difficulty")
-    private Users user;
+//    @OneToOne(mappedBy = "difficulty")
+//    private Users user;
 }

--- a/src/main/java/com/finut/finut_server/domain/user/Users.java
+++ b/src/main/java/com/finut/finut_server/domain/user/Users.java
@@ -3,11 +3,13 @@ package com.finut.finut_server.domain.user;
 
 import com.finut.finut_server.domain.BaseTimeEntity;
 import com.finut.finut_server.domain.difficulty.Difficulty;
+import com.finut.finut_server.domain.difficulty.DifficultyType;
 import com.finut.finut_server.domain.quizDone.QuizDone;
 import com.finut.finut_server.domain.level.Level;
 import com.finut.finut_server.domain.level.LevelName;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.mapping.ToOne;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -42,7 +44,7 @@ public class Users extends BaseTimeEntity {
     @Column(nullable = false)
     private Long money = 100000L;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "levelId", referencedColumnName = "id")
     private Level level;
 
@@ -64,9 +66,7 @@ public class Users extends BaseTimeEntity {
     @Column(nullable = false)
     private int levelQuizCount = 0;
 
-
-
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "difficulty")
     private Difficulty difficulty;
 
@@ -105,6 +105,11 @@ public class Users extends BaseTimeEntity {
         if (this.level == null) {
             this.level = new Level(); // 또는 LevelRepository를 사용해 ID가 1인 Level을 설정
             this.level.setId(1L); // 기본값으로 ID가 1인 Level 설정
+        }
+
+        if (this.difficulty == null) {
+            this.difficulty = new Difficulty();
+            this.difficulty.setDifficulty(DifficultyType.LO);
         }
     }
 }


### PR DESCRIPTION
## Summary
응답 데이터 통일
Difficulty Default 값 지정
오류 수정
## Description
- 오늘의 뉴스 Controller 응답 데이터 통일
- 퀴즈 Controller 응답 데이터 통일
- Users에 데이터 추가 시, Difficulty의 Default 값으로 LO 설정
- Users와 Difficulty/Level 사이의 OneToOne 관계로 인해 발생한 오류 해결
### ➕ ETC
기존에 **Users 테이블이 생성되어 있다면** ManyToOne으로 변경해도 **unique 제약조건이 없어지지 않아** 오류 발생..!!!
아래의 과정을 통해 외래키 제약조건, 유니크 제약조건 순으로 삭제한 뒤, 실행하면 원래 ManyToOne으로 생성했을 때의 Users 테이블처럼 동작
(+ OneToOne으로 속성 지정하면 자동으로 Unique 속성 갖게 된다고 함!) 

1. `SHOW CREATE TABLE users;` : SQL문에서 외래 키 제약조건 이름 확인
2. `ALTER TABLE users DROP FOREIGN KEY <constraint_name>;` : 외래 키 제약조건 삭제
3. `SHOW INDEX FROM users;` : 유니크 제약조건에 해당하는 인덱스 확인
4. `ALTER TABLE users DROP INDEX <unique_index_name>;` : 유니크 제약조건 삭제

이후 새로운 사용자로 로그인하게 된다면 level_id = 1, difficulty = "LO"를 가진 사용자 생성!